### PR TITLE
feat: split React and Cloudflare TS libraries

### DIFF
--- a/reaktor-ts-cloudflare/README.md
+++ b/reaktor-ts-cloudflare/README.md
@@ -1,0 +1,7 @@
+# reaktor-ts-cloudflare
+
+TypeScript utilities for building Cloudflare Workers.
+
+## Usage
+
+Import the default handler and customize the `fetch` method for your worker.

--- a/reaktor-ts-cloudflare/eslint.config.js
+++ b/reaktor-ts-cloudflare/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import { globalIgnores } from 'eslint/config'
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  {
+    files: ['src/**/*.ts'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.serviceworker,
+    },
+  },
+])

--- a/reaktor-ts-cloudflare/package.json
+++ b/reaktor-ts-cloudflare/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "reaktor-ts-cloudflare",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250906.0",
+    "@eslint/js": "^9.33.0",
+    "eslint": "^9.33.0",
+    "globals": "^16.3.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.39.1"
+  },
+  "dependencies": {
+    "reaktor-ts-core": "file:../reaktor-ts-core"
+  }
+}

--- a/reaktor-ts-cloudflare/src/index.ts
+++ b/reaktor-ts-cloudflare/src/index.ts
@@ -1,0 +1,7 @@
+import { greet } from 'reaktor-ts-core'
+
+export default {
+  async fetch(): Promise<Response> {
+    return new Response(greet('Cloudflare'))
+  },
+}

--- a/reaktor-ts-cloudflare/tsconfig.json
+++ b/reaktor-ts-cloudflare/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["ES2021", "DOM"],
+    "moduleResolution": "Node",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/reaktor-ts-core/README.md
+++ b/reaktor-ts-core/README.md
@@ -1,0 +1,3 @@
+# reaktor-ts-core
+
+Common TypeScript utilities shared by reaktor-ts-react and reaktor-ts-cloudflare.

--- a/reaktor-ts-core/eslint.config.js
+++ b/reaktor-ts-core/eslint.config.js
@@ -1,0 +1,10 @@
+import eslint from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist'],
+  }
+)

--- a/reaktor-ts-core/package.json
+++ b/reaktor-ts-core/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "reaktor-ts-core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.33.0",
+    "eslint": "^9.33.0",
+    "globals": "^16.3.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.39.1"
+  }
+}

--- a/reaktor-ts-core/src/index.ts
+++ b/reaktor-ts-core/src/index.ts
@@ -1,0 +1,3 @@
+export function greet(target: string): string {
+  return `Hello from reaktor-ts-core to ${target}`
+}

--- a/reaktor-ts-core/tsconfig.json
+++ b/reaktor-ts-core/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["ES2017"],
+    "moduleResolution": "Node",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/reaktor-ts-react/README.md
+++ b/reaktor-ts-react/README.md
@@ -1,0 +1,7 @@
+# reaktor-ts-react
+
+Library that wires up React Router v7 with Material UI and emotion for TypeScript projects.
+
+## Usage
+
+Install the package and render the exported `App` component inside your router configuration.

--- a/reaktor-ts-react/eslint.config.js
+++ b/reaktor-ts-react/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import tseslint from 'typescript-eslint'
+import { globalIgnores } from 'eslint/config'
+
+export default tseslint.config([
+  globalIgnores(['dist']),
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+  },
+])

--- a/reaktor-ts-react/package.json
+++ b/reaktor-ts-react/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "reaktor-ts-react",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^7.3.2",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
+    "reaktor-ts-core": "file:../reaktor-ts-core"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.33.0",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "eslint": "^9.33.0",
+    "globals": "^16.3.0",
+    "typescript": "~5.8.3",
+    "typescript-eslint": "^8.39.1"
+  }
+}

--- a/reaktor-ts-react/src/App.tsx
+++ b/reaktor-ts-react/src/App.tsx
@@ -1,0 +1,23 @@
+import { AppBar, Box, Container, Toolbar, Typography } from '@mui/material'
+import { Link, Outlet } from 'react-router-dom'
+
+export default function App() {
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Reaktor TS React
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 2 }}>
+            <Link to="/">Home</Link>
+            <Link to="/about">About</Link>
+          </Box>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 4 }}>
+        <Outlet />
+      </Container>
+    </>
+  )
+}

--- a/reaktor-ts-react/src/index.ts
+++ b/reaktor-ts-react/src/index.ts
@@ -1,0 +1,3 @@
+export { default as App } from './App'
+export { default as Home } from './routes/Home'
+export { default as About } from './routes/About'

--- a/reaktor-ts-react/src/routes/About.tsx
+++ b/reaktor-ts-react/src/routes/About.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <h2>About</h2>
+}

--- a/reaktor-ts-react/src/routes/Home.tsx
+++ b/reaktor-ts-react/src/routes/Home.tsx
@@ -1,0 +1,5 @@
+import { greet } from 'reaktor-ts-core'
+
+export default function Home() {
+  return <h2>{greet('React')}</h2>
+}

--- a/reaktor-ts-react/tsconfig.json
+++ b/reaktor-ts-react/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["ES2017", "DOM"],
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- extract client-side code into `reaktor-ts-react` library using React Router v7, Material UI, and emotion
- add `reaktor-ts-cloudflare` library for Cloudflare Worker handlers
- introduce `reaktor-ts-core` with shared utilities used by the React and Cloudflare packages
- remove previous monolithic `reaktor-web` template

## Testing
- `cd reaktor-ts-core && npm install`
- `cd reaktor-ts-core && npm run build`
- `cd reaktor-ts-core && npm run lint`
- `cd reaktor-ts-react && npm install`
- `cd reaktor-ts-react && npm run build`
- `cd reaktor-ts-react && npm run lint`
- `cd reaktor-ts-cloudflare && npm install`
- `cd reaktor-ts-cloudflare && npm run build`
- `cd reaktor-ts-cloudflare && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc47904e3c83328199d504c6e8eb68