### PR TITLE
Fix linguist language stats and expand documentation for all modules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,19 @@
+# Vendored dependencies
 .github_modules/** linguist-vendored=true
+
+# Generated code
 **/ts/export/** linguist-generated=true
 **/package-lock.json linguist-generated=true
 dependeasy/bin/** linguist-generated=true
 *.mjs.map linguist-generated=true
 *.d.mts linguist-generated=true
+
+# Generated documentation (HTML from Dokka/KDoc)
+docs/** linguist-documentation=true
+**/docs/**/*.html linguist-documentation=true
+
+# Website (Docusaurus)
+website/** linguist-documentation=true
+
+# Experiments
+experiments/** linguist-vendored=true

--- a/README.md
+++ b/README.md
@@ -1,113 +1,336 @@
 # Reaktor
 
-Reaktor is a Kotlin Multiplatform application framework for building graph-structured apps and services across Android, iOS, JVM, JS, Cloudflare Workers, and native C++ interop.
+Reaktor is a **Kotlin Multiplatform application framework** for building graph-structured apps and services across Android, iOS, JVM, JavaScript, Cloudflare Workers, and native C++ interop.
 
 It is the shared runtime used by:
 - [BestBuds](https://github.com/shibasis0801/bestbuds/blob/main/README.md)
 - `Manna`
 
+## Graph Blueprint
+
+The graph blueprint is a live visualization of how a Reaktor application is assembled. Every screen, service, repository, and navigation binding is a node in the graph, wired together through typed ports and edges.
+
+![Reaktor Graph Blueprint - BestBuds application graph showing nodes, routes, containers, services, and navigation wires](assets/graph-blueprint.png)
+
+*BestBuds running on Reaktor: screens (green), routes (blue), containers (yellow), services/data (orange), with navigation wires (dark blue) and data wires (green lines) connecting them.*
+
 ## What Reaktor is for
 
 Reaktor is built around a few stable ideas:
-- graph-first composition: apps and services are assembled as graphs of nodes
-- typed ports and edges: features talk through explicit contracts instead of ad-hoc globals
-- capability composition: lifecycle, concurrency, DI, navigation, storage, auth, telemetry
-- shared service contracts: the same request/response types can back clients and servers
-- platform adapters: Android, iOS, JVM, JS, Cloudflare, Google, native C++
+- **Graph-first composition**: apps and services are assembled as directed graphs of nodes
+- **Typed ports and edges**: features communicate through explicit contracts, not ad-hoc globals
+- **Capability composition**: lifecycle, concurrency, DI, navigation, storage, auth, telemetry are all composable mixins
+- **Shared service contracts**: the same request/response types back both clients and servers
+- **Platform adapters**: Android, iOS, JVM, JS, Cloudflare, Google Cloud, native C++
 
-## Core modules
+---
 
-| Module | Purpose |
-| --- | --- |
-| `reaktor-core` | adapters, feature registry, capabilities, common runtime primitives |
-| `reaktor-graph-port` | typed provider/consumer ports and edges |
-| `reaktor-graph` | graph runtime, navigation, node lifecycle, service integration |
-| `reaktor-io` | request/response contracts, route patterns, transport helpers |
-| `reaktor-auth` | social login, JWT verification, RBAC models, auth service contracts |
-| `reaktor-db` | object database, repositories, graph database policy helpers |
-| `reaktor-cloudflare` | Workers, D1, R2, Durable Objects, PartyKit, service bindings |
-| `reaktor-google` | Google Pub/Sub adapters and related integrations |
-| `reaktor-media` | camera, image, speech, gallery, media caching |
-| `reaktor-location` | cross-platform location adapters |
-| `reaktor-notification` | notification adapter surface |
-| `reaktor-work` | background task orchestration |
-| `reaktor-ui` | shared UI tokens and components |
-| `reaktor-flexbuffer` | native FlexBuffers utility layer and KMP bridge |
-| `reaktor-ffi` | Hermes/native bridge layer |
-| `dependeasy` | internal Gradle plugin and target orchestration |
+## Module Overview
+
+Every module has a **stability level** indicating its maturity:
+
+| Level | Meaning |
+|---|---|
+| **Stable** | Production-tested, API unlikely to change. Used by shipping products. |
+| **Experimental** | Integrated and functional, but API may evolve. Used in production with care. |
+| **Early** | Partial implementation. Functional for its current scope but not feature-complete. |
+| **Brainstorming** | Placeholder or minimal skeleton. Reserved for future development. |
+| **Paused** | Previously active, now on hold. Code preserved but not recommended for new work. |
+
+---
+
+## Modules
+
+### Foundation
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-core/README.md"><code>reaktor-core</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Adapters, feature registry, capabilities, cross-platform runtime primitives</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-graph-port"><code>reaktor-graph-port</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Typed provider/consumer ports, edges, and port wiring</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-graph/README.md"><code>reaktor-graph</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Graph runtime, node lifecycle, navigation, DI, services</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-io/README.md"><code>reaktor-io</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Route patterns, request/response shapes, HTTP/WebSocket transport</td>
+</tr>
+</table>
+
+### Identity and Data
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-auth/README.md"><code>reaktor-auth</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>OAuth2/OIDC social login (Google, Apple), JWT verification, RBAC</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-db/README.md"><code>reaktor-db</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Object database, observable stores, cache policies, offline-first repositories</td>
+</tr>
+</table>
+
+### Server and Cloud
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-cloudflare/README.md"><code>reaktor-cloudflare</code></a></td>
+  <td><strong>Experimental</strong></td>
+  <td>JS (Cloudflare Workers)</td>
+  <td>Workers, D1, R2, Durable Objects, PartyKit, Hono, service bindings</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-google/README.md"><code>reaktor-google</code></a></td>
+  <td><strong>Experimental</strong></td>
+  <td>JVM, JS, Android, iOS</td>
+  <td>Google Cloud Pub/Sub adapters (publish, subscribe, pull, ack)</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-work/README.md"><code>reaktor-work</code></a></td>
+  <td><strong>Experimental</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Background task orchestration with platform-native schedulers</td>
+</tr>
+</table>
+
+### Native Interop
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-ffi/README.md"><code>reaktor-ffi</code></a></td>
+  <td><strong>Experimental</strong></td>
+  <td>Android (JNI), iOS (cinterop)</td>
+  <td>Native bridge layer with Hermes JS engine integration</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-flexbuffer/README.md"><code>reaktor-flexbuffer</code></a></td>
+  <td><strong>Experimental</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>FlexBuffers serialization with native C++ utility layer</td>
+</tr>
+</table>
+
+### UI and Presentation
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-ui/README.md"><code>reaktor-ui</code></a></td>
+  <td><strong>Early</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Design tokens, Compose-first components, cross-platform theming</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-media/README.md"><code>reaktor-media</code></a></td>
+  <td><strong>Early</strong></td>
+  <td>Android, iOS</td>
+  <td>Camera, gallery, image caching, speech recognition/synthesis adapters</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-web"><code>reaktor-web</code></a></td>
+  <td><strong>Brainstorming</strong></td>
+  <td>Android, iOS, JS</td>
+  <td>WebView abstraction for embedding web content in native apps</td>
+</tr>
+</table>
+
+### Platform Services
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./reaktor-location/README.md"><code>reaktor-location</code></a></td>
+  <td><strong>Early</strong></td>
+  <td>Android, iOS</td>
+  <td>Cross-platform location adapters (GPS, map interface)</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-telemetry"><code>reaktor-telemetry</code></a></td>
+  <td><strong>Early</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>OpenTelemetry tracing, Firebase Analytics and Crashlytics adapters</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-notification/README.md"><code>reaktor-notification</code></a></td>
+  <td><strong>Brainstorming</strong></td>
+  <td>Android, iOS, JVM, JS</td>
+  <td>Notification delivery and registration adapter surface</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-tactile/README.md"><code>reaktor-tactile</code></a></td>
+  <td><strong>Brainstorming</strong></td>
+  <td>-</td>
+  <td>Reserved for touch and haptics APIs. Not built out yet.</td>
+</tr>
+</table>
+
+### Tooling and Codegen
+
+<table>
+<tr><th>Module</th><th>Stability</th><th>Platforms</th><th>Description</th></tr>
+<tr>
+  <td><a href="./dependeasy"><code>dependeasy</code></a></td>
+  <td><strong>Stable</strong></td>
+  <td>Gradle plugin</td>
+  <td>Internal Gradle plugin for multiplatform target orchestration and native builds</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-compiler"><code>reaktor-compiler</code></a></td>
+  <td><strong>Early</strong></td>
+  <td>JVM (build-time)</td>
+  <td>KSP processor for JS Promise wrappers of suspend functions</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-mcp"><code>reaktor-mcp</code></a></td>
+  <td><strong>Brainstorming</strong></td>
+  <td>JVM</td>
+  <td>Model Context Protocol client and server stubs</td>
+</tr>
+<tr>
+  <td><a href="./reaktor-react/README.md"><code>reaktor-react</code></a></td>
+  <td><strong>Paused</strong></td>
+  <td>Android, iOS</td>
+  <td>React Native JSI bridge. Not actively maintained.</td>
+</tr>
+</table>
+
+---
 
 ## Architecture
 
 ### Graph runtime
 
-Reaktor graphs are assembled from:
-- `Graph`: a scoped runtime containing nodes, navigation, DI, coroutine scope, and lifecycle
-- `Node`: the unit of behavior; logic, route, container, controller, or actor-like node
-- `ProviderPort<T>` / `ConsumerPort<T>`: typed contracts between nodes
-- `Edge<T>`: validated connection between provider and consumer
+Reaktor applications are assembled from directed graphs:
 
-This model is what BestBuds uses for screen graphs, navigation, repositories, and service composition.
+- **`Graph`** is a scoped runtime container owning nodes, DI scope, lifecycle state, coroutine scope, and navigation state.
+- **`Node`** is the unit of behavior. Variants include `BasicNode`, `ControllerNode` (stateful, ViewModel-like), `RouteNode` (navigation destination), `ContainerNode` (nested sub-graphs), and `ServiceNode` (HTTP/RPC service wrapper).
+- **`ProviderPort<T>` / `ConsumerPort<T>`** are typed contracts. Nodes never call each other directly; they communicate through ports.
+- **`Edge<T>`** connects a consumer port to a provider port. Validated at connection time with type and key matching.
+- **`autoWire()`** automatically matches unconnected consumer ports to provider ports by type and key within a graph.
+
+### Capabilities (mixins)
+
+Behavior is composed into graphs and nodes through delegation, not deep inheritance:
+
+| Capability | What it provides |
+|---|---|
+| `LifecycleCapability` | State machine: Created, Restoring, Attaching, Saving, Destroying |
+| `ConcurrencyCapability` | Owned `CoroutineScope`, dispatcher, structured concurrency helpers |
+| `DependencyCapability` | Scoped DI via Koin with parent/child scope hierarchy |
+| `NavigationCapability` | Back stack, `Push`/`Pop`/`Replace`/`Return` commands, cross-graph routing |
 
 ### Adapters and features
 
-Platform-specific capabilities are exposed through adapters registered in the global `Feature` registry. Examples:
-- `Feature.Auth`
-- `Feature.Database`
-- `Feature.Sql`
-- `Feature.Storage`
-- `Feature.Permission`
-- `Feature.GooglePubSub`
+Platform-specific capabilities are installed through adapters registered in the global `Feature` registry:
 
-The adapter pattern keeps the framework code platform-neutral while allowing Android, iOS, JVM, and JS controllers underneath.
+```kotlin
+// At app startup
+Feature.Auth = AndroidAuthAdapter(activity)
+Feature.Database = SqliteObjectDatabase(context)
+Feature.Telemetry = TelemetryAdapter(activity, createOpenTelemetry { ... })
+
+// In shared code (any platform)
+val user = Feature.Auth?.login(appId, environment, UserProvider.GOOGLE)
+```
 
 ### Service model
 
-Reaktor services are defined once and reused across client and server code.
+Services are defined once and reused across client and server:
 
-The current model supports:
-- typed `Request` / `Response`
-- route-aware handlers like `GetHandler`, `PostHandler`, `PutHandler`, `DeleteHandler`
-- transport metadata such as status code and headers
-- interceptor/policy hooks
-- mounting onto server runtimes such as Spring or Cloudflare Workers
+- Typed `Request` / `Response` with kotlinx.serialization
+- Route-aware handlers: `GetHandler`, `PostHandler`, `PutHandler`, `DeleteHandler`
+- Transport metadata (status codes, headers)
+- Interceptor chains for auth, logging, caching
+- Mountable onto Spring WebFlux (JVM) or Cloudflare Workers (JS)
+- `ServiceNode` wraps services as graph nodes, exposing handlers as typed ports
+
+### Navigation
+
+Navigation is graph-native, not bolted on:
+
+- `RouteNode` defines URL-like patterns (e.g., `/chats/{id}`)
+- `NavigationEdge` connects routes with typed payloads
+- `ContainerNode` manages nested graphs (e.g., bottom navigation tabs)
+- Cross-graph navigation bubbles up automatically to find the right container
+- `ObservableStack` backs the navigation state, observable by the UI
 
 ### Cloudflare and realtime
 
-`reaktor-cloudflare` now covers:
-- Workers
-- D1
-- R2
-- Durable Objects
-- service bindings
-- PartyKit room/server wrappers
+`reaktor-cloudflare` provides typed Kotlin/JS access to the full Cloudflare platform:
 
-This is what BestBuds uses for its worker and realtime deployment surface.
+- **Workers** with Hono routing and typed binding resolution
+- **D1** SQLite with query builders and typed row mapping
+- **R2** object storage with streaming and JSON support
+- **Durable Objects** for persistent actor-like computation
+- **PartyKit** for real-time WebSocket rooms with hibernation support
+- **Service bindings** for worker-to-worker calls
+- **Vectorize** for embedding/vector database queries
 
 ### Native interop
 
-Reaktor also ships a unified native toolchain path via `dependeasy`:
-- Android native builds through CMake without AGP `externalNativeBuild`
-- Darwin native builds through generated cinterop + CMake tasks
-- Hermes and FlexBuffers integration for runtime native execution
+Reaktor ships a unified native toolchain path:
+
+- **Android**: JNI bridge via FBJNI with `JAVA_DESCRIPTOR(...)` macro for readable descriptors
+- **iOS**: cinterop + CMake tasks for Darwin native builds
+- **Hermes**: Facebook's JS engine integrated for native code execution
+- **FlexBuffers**: Binary serialization for efficient Kotlin-C++ payload exchange
+- **FFI protocol**: Module name, function name, sequence number, and arguments encoded as a FlexBuffer vector
+
+### Background work
+
+`reaktor-work` abstracts platform-native task schedulers (WorkManager on Android, BGTaskScheduler on iOS, schedulers on JVM/JS) behind a unified API:
+
+Built-in worker shapes: sync, token refresh, analytics upload, media upload, database maintenance, cache cleanup, notification sync, heartbeat, prefetch, log upload.
+
+### Telemetry
+
+`reaktor-telemetry` integrates:
+
+- **OpenTelemetry Kotlin** for distributed tracing (noop by default, zero overhead)
+- **Firebase Analytics** for event logging via GitLive SDK
+- **Firebase Crashlytics** for crash reporting on Android and iOS
+
+---
 
 ## Build model
 
-Reaktor is a composite Gradle build and provides its own internal plugins from `dependeasy`.
+Reaktor is a composite Gradle build with its own internal plugins from `dependeasy`.
 
-Important build characteristics:
-- Kotlin Multiplatform is the default
-- native dependencies such as Hermes and FlatBuffers are bootstrapped into `.github_modules`
-- generated JS exports live under `*/ts/export`
-- consumer repos such as BestBuds use `includeBuild("../reaktor")`
+- Kotlin Multiplatform is the default for all modules
+- Native dependencies (Hermes, FlatBuffers) are bootstrapped into `.github_modules`
+- Generated JS exports live under `*/ts/export`
+- Consumer repos use `includeBuild("../reaktor")` for immediate change propagation
+- KSP is used for compile-time code generation (Promise wrappers, annotations)
 
 ## Quick start
 
 ### Prerequisites
 - Java 21+
 - Android SDK
-- Xcode + iOS platform if building Darwin targets
-- CMake and Ninja for native modules
-- CocoaPods for iOS dependencies
+- Xcode + iOS platform (for Darwin targets)
+- CMake and Ninja (for native modules)
+- CocoaPods (for iOS dependencies)
 
 Detailed setup: [SETUP.md](./SETUP.md)
 
@@ -117,36 +340,71 @@ Detailed setup: [SETUP.md](./SETUP.md)
 ./gradlew build
 ```
 
-### Useful targets
+### Run tests
 
 ```bash
+# Graph runtime tests
 ./gradlew :reaktor-graph:allTests
 ./gradlew :reaktor-graph-port:allTests
+
+# Native bridge (Android)
 ./gradlew :reaktor-ffi:assembleDebug
+./gradlew :reaktor-flexbuffer:assembleDebug
+
+# Native bridge (iOS)
+./gradlew :reaktor-ffi:iphoneosCMake
 ./gradlew :reaktor-flexbuffer:iphoneosCMake
 ```
 
 ## Documentation map
 
-- [SETUP.md](./SETUP.md): local machine setup and build prerequisites
-- [reaktor-core](./reaktor-core/README.md)
-- [reaktor-graph](./reaktor-graph/README.md)
-- [reaktor-auth](./reaktor-auth/README.md)
-- [reaktor-db](./reaktor-db/README.md)
-- [reaktor-cloudflare](./reaktor-cloudflare/README.md)
-- [reaktor-ffi](./reaktor-ffi/README.md)
-- [reaktor-flexbuffer](./reaktor-flexbuffer/README.md)
-- [tools/maestro](./tools/maestro/README.md)
+| Document | Purpose |
+|---|---|
+| [SETUP.md](./SETUP.md) | Local machine setup and build prerequisites |
+| [LLM_CONTEXT.md](./LLM_CONTEXT.md) | Architecture context for AI assistants |
+| [reaktor-core](./reaktor-core/README.md) | Core runtime layer |
+| [reaktor-graph](./reaktor-graph/README.md) | Graph runtime |
+| [reaktor-auth](./reaktor-auth/README.md) | Authentication and RBAC |
+| [reaktor-auth/TECHNICAL_README.md](./reaktor-auth/TECHNICAL_README.md) | Auth implementation details |
+| [reaktor-auth/WEB_IMPLEMENTATION_SUMMARY.md](./reaktor-auth/WEB_IMPLEMENTATION_SUMMARY.md) | Web auth specifics |
+| [reaktor-db](./reaktor-db/README.md) | Database and persistence |
+| [reaktor-cloudflare](./reaktor-cloudflare/README.md) | Cloudflare Workers integration |
+| [reaktor-google](./reaktor-google/README.md) | Google Cloud Pub/Sub |
+| [reaktor-ffi](./reaktor-ffi/README.md) | Native bridge layer |
+| [reaktor-flexbuffer](./reaktor-flexbuffer/README.md) | FlexBuffers serialization |
+| [reaktor-work](./reaktor-work/README.md) | Background task orchestration |
+| [tools/maestro](./tools/maestro/README.md) | Mobile E2E testing |
+
+## Technology stack
+
+| Aspect | Technologies |
+|---|---|
+| **Primary language** | Kotlin (Multiplatform) |
+| **Secondary languages** | C++ (native interop), TypeScript (JS platform exports) |
+| **UI** | Jetpack Compose (Android, iOS, Desktop) |
+| **Server** | Spring WebFlux, Cloudflare Workers (Hono) |
+| **Database** | SQLite (SQLDelight), PostgreSQL (Exposed ORM), D1, Neo4j |
+| **Auth** | Google Sign-In, Apple Sign-In, JWT, Spring Security |
+| **Serialization** | kotlinx.serialization, FlexBuffers, FlatBuffers |
+| **Networking** | Ktor, WebSocket, PartyKit |
+| **Native** | JNI/FBJNI, Hermes, CMake, cinterop |
+| **Observability** | OpenTelemetry, Firebase Analytics, Firebase Crashlytics |
+| **Build** | Gradle, dependeasy (custom plugin), KSP |
+| **Testing** | Maestro (mobile E2E), Kotlin Test |
 
 ## Status
 
-Reaktor is not a polished general-purpose public framework yet. It is an active product-backed runtime. The important parts are real and in production use:
-- graph runtime
-- service contracts
-- auth
-- Cloudflare workers
-- build tooling
-- mobile testing tooling
-- native bridge path
+Reaktor is not a polished general-purpose public framework yet. It is an **active product-backed runtime**. The important parts are real and in production use:
 
-Some modules are intentionally thinner or still evolving.
+- Graph runtime and navigation
+- Service contracts (client + server)
+- Authentication (Google, Apple, JWT, RBAC)
+- Database and offline-first persistence
+- Cloudflare Workers deployment
+- Native bridge (Hermes + FlexBuffers)
+- Build tooling (dependeasy)
+- Mobile testing (Maestro)
+- Background work scheduling
+- Google Pub/Sub integration
+
+Some modules (notification, tactile, MCP, web) are intentionally thin or still at the brainstorming stage.

--- a/reaktor-auth/README.md
+++ b/reaktor-auth/README.md
@@ -1,45 +1,74 @@
 # reaktor-auth
 
-`reaktor-auth` provides the shared authentication model used across Reaktor products.
+> **Stability: Stable**
+
+`reaktor-auth` provides cross-platform OAuth2/OIDC social login, JWT verification, and role-based access control (RBAC) for Reaktor products.
 
 ## What it includes
 
-- shared auth DTOs and service contracts
 - Google and Apple login adapters for Android and iOS
-- web auth adapter surface
-- JWT verification on the server
-- app / user / role / permission / context / session models
-- multi-tenant RBAC schema for JVM server deployments
+- Web auth adapter surface (Google Identity Services, Sign in with Apple JS)
+- JWT verification on the server (Spring Security)
+- Shared auth DTOs and service contracts
+- App / user / role / permission / context / session models
+- Multi-tenant RBAC schema for JVM server deployments (PostgreSQL + Exposed ORM)
+- Token caching and refresh via `AuthObjectStore`
+- Compose UI components: `LoginButtons`, `GoogleIcon`, `AppleIcon`
 
-## Current shape
+## Platforms
 
 ### Client side
-- Android: Google login implemented, Apple still depends on the chosen Android flow strategy
-- iOS: Google and Apple login implemented
-- JS/Web: adapter surface exists, web auth implementation is documented separately
+- **Android**: Google login via Credential Manager API. Apple login planned.
+- **iOS**: Google login via GoogleSignIn pod (8.0.0). Apple login via AuthenticationServices.
+- **JS/Web**: Adapter surface exists. Google Identity Services and Apple Sign-In JS interop defined.
 
 ### Server side
-- JVM auth server with token verification and profile/user resolution
-- typed login responses with explicit failure cases
+- **JVM**: Spring Boot auth server with JWT verification, profile/user resolution, token minting.
+- Full RBAC schema: Users, Apps, Roles, Permissions, Sessions, Contexts (Exposed ORM + PostgreSQL).
 
-## Important contracts
+## Key types
 
-- `LoginRequest`
-- `LoginResponse`
-- `AppService`
-- `AuthAdapter`
-- `AuthProvider`
-- `UserProvider`
+### Auth flow
+
+| Type | Purpose |
+|---|---|
+| `AuthAdapter<Controller>` | Main auth bridge. Manages providers, login flow, token caching. |
+| `AuthProvider<Adapter, User>` | Abstract provider (Google, Apple). Handles platform-specific login. |
+| `AuthProviderUser` | User data from provider: `idToken`, `emailId`, `givenName`, `familyName` |
+| `GoogleUser` / `AppleUser` | Provider-specific user data classes |
+
+### Service contracts
+
+| Type | Purpose |
+|---|---|
+| `AuthService` | Service with `login`, `mintPat`, `verifyPat` handlers |
+| `LoginRequest` | `idToken`, `appId`, `provider`, name fields, profile data |
+| `LoginResponse` | Sealed: `Success` (user, tokens) or typed failures |
+| `AppService` | App management: `getAll`, `getApp` |
+
+### LoginResponse failures
+
+`InvalidIdToken`, `InvalidAppId`, `UnsupportedUserProvider`, `RequiresUserName`, `RequiresUserProfile`, `AppLoginFailure`, `ServerError`
+
+### RBAC (server)
+
+`User`, `Role`, `Permission`, `Session`, `Context` - Exposed ORM entities with `Auditable` mixin for creation/modification tracking.
+
+## Graph integration
+
+- `AuthNode` - Integrates auth adapter with graph lifecycle
+- `SecuredPort` - Wraps ports requiring authentication
+- Feature slot: `Feature.Auth`
 
 ## Documentation
 
-- [TECHNICAL_README.md](./TECHNICAL_README.md)
-- [WEB_IMPLEMENTATION_SUMMARY.md](./WEB_IMPLEMENTATION_SUMMARY.md)
+- [TECHNICAL_README.md](./TECHNICAL_README.md) - Implementation details
+- [WEB_IMPLEMENTATION_SUMMARY.md](./WEB_IMPLEMENTATION_SUMMARY.md) - Web auth specifics
 
 ## Typical usage
 
 Use this module when you need:
-- provider login on mobile
+- Provider login on mobile (Google, Apple)
 - JWT verification on the backend
-- shared request/response contracts between app and server
-- app-scoped RBAC entities
+- Shared request/response contracts between app and server
+- App-scoped RBAC entities

--- a/reaktor-cloudflare/README.md
+++ b/reaktor-cloudflare/README.md
@@ -1,51 +1,59 @@
 # reaktor-cloudflare
 
-`reaktor-cloudflare` is the Kotlin/JS runtime layer for Cloudflare deployments.
+> **Stability: Experimental** - Production-integrated in BestBuds but API may evolve.
+
+`reaktor-cloudflare` is the Kotlin/JS runtime layer for Cloudflare deployments. It enables writing Cloudflare Workers in Kotlin instead of TypeScript while maintaining strong typing.
 
 ## What it covers
 
-- Workers
-- D1
-- R2
-- Durable Objects
-- service bindings
-- Vector bindings
-- secrets
-- Hono integration
-- PartyKit integration
+- Workers with Hono routing
+- D1 (SQLite database) with query builders and typed row mapping
+- R2 (object storage) with streaming and JSON support
+- Durable Objects for persistent actor-like computation
+- Service bindings for worker-to-worker calls
+- Vectorize for embedding/vector database queries
+- Secrets management via bindings
+- PartyKit integration for real-time WebSocket rooms (with hibernation support)
+
+## Platforms
+
+JavaScript/Kotlin/JS only (Cloudflare Workers runtime)
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `CloudflareContext` | Central access point for all bindings in request context |
+| `CloudflareWorkerRequest` | Typed wrapper for incoming requests |
+| `CloudflareResponse` | Response with typed access |
+| `CloudflareWorker` | Worker definition |
+| `CloudflareEnv` | Marker interface for environment bindings |
+| `WorkerService` | Service-to-service calls via bindings |
+| `Binding<T>` | Typed binding resolution |
+| `D1Database` / `D1Mutation` | SQLite database interaction |
+| `R2Bucket` / `R2Object` | Object storage (files) |
+| `DurableObjectNamespace` / `DurableObjectStub` / `DurableObjectStorage` | Persistent state |
+| `CloudflareDurableObject` | Durable Object definition |
+| `VectorIndex` / `VectorizeVector` / `VectorizeMatches` | Vector database queries |
+| `PartyKitServer` / `PartyKitRoom` / `PartyKitConnection` | Real-time WebSocket support |
 
 ## Design goals
 
-- typed access to Cloudflare bindings from Kotlin
-- request-aware binding lookup instead of raw `dynamic`
-- shared service contracts mounted directly on Cloudflare handlers
-- escape hatches for raw responses, multipart handling, and websocket/realtime surfaces
-
-## Important types
-
-- `CloudflareContext`
-- `Binding<T>` and concrete binding types
-- `CloudflareWorkerRequest`
-- `CloudflareResponse`
-- `WorkerService`
-- `CloudflareWorker`
-- `CloudflareDurableObject`
-- `PartyKitServer`
-- `PartyKitRoom`
+- Typed access to Cloudflare bindings from Kotlin
+- Request-aware binding lookup instead of raw `dynamic`
+- Shared service contracts mounted directly on Cloudflare handlers
+- Escape hatches for raw responses, multipart handling, and WebSocket surfaces
 
 ## Current use in production
 
 BestBuds uses this module for:
-- social worker
-- messaging worker
-- media worker
-- config worker
-- realtime PartyKit chat
+- Social worker
+- Messaging worker
+- Media worker
+- Config worker
+- Realtime PartyKit chat
 
-## Typical usage
+## Dependencies
 
-Use this module when you want to:
-- implement a worker in Kotlin instead of TypeScript
-- resolve bindings safely from request context
-- mount Reaktor services into Cloudflare routes
-- access PartyKit from Kotlin with a typed wrapper surface
+- `reaktor-core`, `reaktor-graph`, `reaktor-io`
+- NPM: `hono` (4.9.8), `partykit` (0.0.115), `postgres` (3.4.5)

--- a/reaktor-core/README.md
+++ b/reaktor-core/README.md
@@ -1,50 +1,93 @@
 # reaktor-core
 
-`reaktor-core` is the lowest shared runtime layer in Reaktor.
+> **Stability: Stable**
+
+`reaktor-core` is the lowest shared runtime layer in Reaktor. Every other module depends on it.
 
 ## Responsibilities
 
-- adapter base classes
-- feature registry
-- capability primitives
-- cross-platform runtime helpers
-- common network primitives such as `Request`, `Response`, and `StatusCode`
-- platform-specific helpers for permissions, storage, dispatch, lifecycle integration, and weak references
+- Adapter base classes for platform bridging
+- Feature registry for global service slots
+- Capability primitives (lifecycle, concurrency, dependency injection)
+- Cross-platform runtime helpers
+- Common network primitives: `Request`, `Response`, `StatusCode`
+- Platform-specific helpers for permissions, storage, dispatch, lifecycle, and weak references
 
-## Key concepts
+## Platforms
+
+Android, iOS (Darwin), JVM, JavaScript/Web
+
+## Key types
 
 ### Adapter
 
 `Adapter<Controller>` is the main controller bridge used throughout the framework.
 
 It provides:
-- weakly-held controller references
-- synchronous and suspend invocation helpers
-- consistent null-controller failure behavior
+- Weakly-held controller references via `WeakRef<Controller>` (safe for mobile lifecycles)
+- Synchronous invocation: `invoke { controller.doSomething() }`
+- Suspend invocation: `suspended { controller.fetchData() }`
+- Result-aware variants: `invokeResult`, `suspendedResult`
+- Consistent null-controller failure behavior when the controller is garbage collected
 
 ### Feature registry
 
-`Feature` is the global slot registry used to install shared platform services such as:
-- auth
-- database
-- SQL
-- storage
-- permissions
-- Google Pub/Sub
+`Feature` is the global singleton slot registry. Platform services are installed at startup and accessed from shared code:
 
-### Capability base
+```kotlin
+// Install at startup (platform-specific)
+Feature.Auth = AndroidAuthAdapter(activity)
+Feature.Database = SqliteObjectDatabase(context)
 
-Capabilities are the reusable behaviors layered into graphs and nodes:
-- `ConcurrencyCapability`
-- `LifecycleCapability`
-- `DependencyCapability`
-- other higher-level capabilities build on the same pattern
+// Access from shared code (any platform)
+val auth = Feature.Auth
+```
+
+Available slots include `Auth`, `Database`, `Sql`, `Storage`, `Permission`, `GooglePubSub`, `Telemetry`.
+
+New slots are created with the `CreateSlot<T>` property delegate:
+```kotlin
+var Feature.MyService by CreateSlot<MyServiceAdapter<*>>()
+```
+
+### Capabilities
+
+Capabilities are reusable behavior mixins composed into graphs and nodes via delegation:
+
+| Capability | Purpose |
+|---|---|
+| `ConcurrencyCapability` | Owns a `CoroutineScope` and dispatcher; provides `launch`, `async`, `execute`, `withContext` |
+| `LifecycleCapability` | State machine: Created, Restoring, Attaching, Saving, Destroying |
+| `DependencyCapability` | Scoped DI access |
+| `AtomicCapability` | Thread-safe close via atomicfu |
+
+### Network primitives
+
+- `Request` / `Response` - Base HTTP shapes
+- `StatusCode` - HTTP status enum (OK, BAD_REQUEST, UNAUTHORIZED, etc.)
+- `JsonResponse` - Serializable response wrapper
+
+### Platform adapters
+
+- `PermissionAdapter` - Permission request/result handling (Android, iOS)
+- `StorageAdapter` - File system access
+- `FileAdapter` - Cross-platform file I/O
+- `Dispatch` - Platform-specific dispatcher access (main/UI thread)
+
+## Dependencies
+
+- `kotlinx-coroutines` - Structured concurrency
+- `kotlinx-serialization` - JSON serialization
+- `kotlinx-datetime` - Date/time utilities
+- `atomicfu` - Lock-free thread safety
+- `kotlinx-collections-immutable` - Persistent collections
+- `kermit` - Cross-platform logging
 
 ## When to put code here
 
 Put code in `reaktor-core` only if it is:
-- product-neutral
-- graph-neutral or foundational to graph/service layers
-- needed by multiple higher-level modules
+- Product-neutral
+- Graph-neutral or foundational to graph/service layers
+- Needed by multiple higher-level modules
 
-If the code depends on graph semantics, it usually belongs in `reaktor-graph` instead.
+If the code depends on graph semantics, it belongs in `reaktor-graph` instead.

--- a/reaktor-db/README.md
+++ b/reaktor-db/README.md
@@ -1,39 +1,62 @@
 # reaktor-db
 
-`reaktor-db` contains Reaktor's data storage abstractions.
+> **Stability: Stable**
+
+`reaktor-db` contains Reaktor's data storage abstractions for offline-first apps and tenant-safe server queries.
 
 ## Responsibilities
 
-- object database abstraction for app-side persistence
-- object stores and observable flows
-- cache policies
-- repository support for offline-first usage
-- graph database policy helpers for tenant-safe Cypher execution
+- Object database abstraction for app-side persistence
+- Object stores and observable flows
+- Cache policies (LRU, TTL)
+- Repository support for offline-first usage (read-through, write-through)
+- Graph database policy helpers for tenant-safe Cypher execution
 
-## Current supported areas
+## Platforms
+
+Android, iOS (Darwin), JVM, JavaScript/Web
+
+## Key types
 
 ### Object database
 
-The current app-facing storage model is based on:
-- `ObjectDatabase`
-- `ObjectStore`
-- `ObjectFlow<T>`
-- cache policy implementations such as TTL/LRU behavior
+| Type | Purpose |
+|---|---|
+| `ObjectDatabase` | Abstract persistence base with event emission (Put, Get, Delete, Clear) |
+| `ObjectStore` | Typed object access with read/write semantics |
+| `ObjectFlow<T>` | Observable reactive flows for stored objects |
+| `StoredObject<T>` | Wrapper with key, value, storeName, timestamps |
+| `JsonSqliteObjectDatabase` | Concrete implementation: JSON + SQLite storage |
 
-### SQL and repository integration
+### Cache policies
 
-Higher-level repositories can layer read-through and write-through caching on top of the object database.
+| Type | Purpose |
+|---|---|
+| `CachePolicy` | Interface for cache eviction strategies |
+| `CachePolicyLRU` | LRU implementation with time-based expiration (TTL) |
 
 ### Graph database policy
 
-The current graph DB surface adds soft multi-tenancy through mandatory parameterization.
+| Type | Purpose |
+|---|---|
+| `GraphDbPolicy` | Tenant safety enforcement for Cypher queries |
+| `MandatoryTenantParameterization` | Validates `$tenant_id` injection in all Cypher queries |
 
-The framework can enforce:
-- mandatory `$tenant_id`
-- query inspection before dispatch
-- automatic binding from the execution context
+The graph DB surface adds soft multi-tenancy through mandatory parameterization, intended for graph databases like Memgraph where tenant isolation is enforced by query shape.
 
-This is intended for graph database usage such as Memgraph, where tenant isolation is enforced by query shape rather than separate physical databases.
+### SQL and sync
+
+| Type | Purpose |
+|---|---|
+| `SqlAdapter` | SQL adapter pattern |
+| `SyncAdapter` | Synchronization support |
+
+## Dependencies
+
+- `reaktor-io`
+- SQLDelight (runtime + platform-specific drivers: Android, iOS native, JDBC, SQLite)
+- Neo4j Java driver (server only)
+- kotlinx-coroutines-jdk8 (server)
 
 ## What this module is not
 

--- a/reaktor-ffi/README.md
+++ b/reaktor-ffi/README.md
@@ -1,29 +1,63 @@
 # reaktor-ffi
 
-`reaktor-ffi` is Reaktor's native bridge layer.
+> **Stability: Experimental** - Production-tested in BestBuds native verification flows.
+
+`reaktor-ffi` is Reaktor's native bridge layer, enabling Kotlin to call C++ and vice versa. It integrates Facebook's Hermes JavaScript engine for native code execution on Android and iOS.
 
 ## What it does today
 
-- provides the Kotlin-facing native bridge surface used by app code
-- hosts the Android JNI and Darwin native bridge entry points
-- wires Hermes into the native bridge path
-- integrates with `reaktor-flexbuffer` for payload exchange
+- Kotlin-facing native bridge surface (`Invokable` interface) for sync and async calls
+- Android JNI bridge via FBJNI with `JAVA_DESCRIPTOR(...)` macro
+- Darwin native bridge via cinterop
+- Hermes JS engine integration for native code execution
+- FlexBuffer-based payload marshaling with `reaktor-flexbuffer`
 
-## Current verified path
+## Platforms
 
-The current production-tested native checks are intentionally simple:
-- Hermes-backed native execution on Android and iOS
-- native FlexBuffer creation in C++ and decoding in Kotlin
+| Platform | Status |
+|---|---|
+| Android | Full JNI + Hermes integration |
+| iOS/Darwin | Native bridge via cinterop |
+| JVM | Stub |
+| JavaScript | Stub |
 
-This is the path used by the BestBuds `/dev` native verification flows.
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Invokable` | Interface for sync/async native invocation |
+| `SyncInvokable` | Synchronous invocation (fun interface) |
+| `AsyncInvokable` | Asynchronous invocation returning `Flow` |
+| `FlexPayload` | Type alias for FlexBuffer `Vector` |
+
+## FFI protocol
+
+Arguments are encoded as a FlexBuffer vector:
+
+| Field | Content |
+|---|---|
+| 0 | Module name |
+| 1 | Function name |
+| 2 | Sequence number (-1 for sync, >= 0 for async flow) |
+| 3+ | Actual function arguments |
 
 ## Important files
 
-- `cpp/droid/AndroidInvokable.*`
-- `cpp/darwin/DarwinInvokable.h`
-- `src/commonMain/.../NativeBridge.kt`
-- platform `NativeBridge.*.kt` actual implementations
+- `cpp/droid/AndroidInvokable.*` - Android JNI bridge
+- `cpp/darwin/DarwinInvokable.h` - iOS native bridge
+- `src/commonMain/.../NativeBridge.kt` - Common bridge interface
+- Platform `NativeBridge.*.kt` actual implementations
 
-## JNI descriptor helper
+## Current verified path
 
-Android JNI classes use the `JAVA_DESCRIPTOR(...)` helper so the call site can stay readable while still producing valid JNI descriptors.
+Intentionally simple and production-tested:
+- Hermes-backed native execution on Android and iOS
+- Native FlexBuffer creation in C++ and decoding in Kotlin
+- Used by the BestBuds `/dev` native verification flows
+- Maestro verifies the result on both platforms
+
+## Dependencies
+
+- `reaktor-core`, `reaktor-flexbuffer`
+- Facebook Hermes Android (0.81.4) - Android native
+- FBJNI - JNI helpers for Android

--- a/reaktor-flexbuffer/README.md
+++ b/reaktor-flexbuffer/README.md
@@ -1,26 +1,37 @@
 # reaktor-flexbuffer
 
-`reaktor-flexbuffer` contains Reaktor's FlexBuffers-native utility layer.
+> **Stability: Experimental** - Production-verified in BestBuds device flows.
+
+`reaktor-flexbuffer` provides Kotlin's bridge to Google's FlexBuffers format -- a flexible binary serialization format faster than JSON with native C++ integration for high-performance scenarios.
+
+## Platforms
+
+Android, iOS (Darwin), JVM, JavaScript/Web
 
 ## What is supported now
 
-- native C++ utility types such as `CBase`, `CppBase`, `Visitor`, and `Matrix`
-- native creation of simple FlexBuffers payloads in C++
-- Kotlin decoding/consumption across Android, iOS, JVM, and JS bridges
-- integration with `reaktor-ffi`
+### Kotlin serialization bridge
 
-## What changed
+- `FlexEncoderV2` - Pooled, allocation-free encoder
+- `FlexDecoderV2` - Pooled, allocation-free decoder with context stack
+- `FlexBufferPool` - Thread-safe encoder/decoder pool
+- Encoding: `T -> kotlinx.serialization -> FlexEncoderV2 -> FlexBuffersBuilder -> ByteArray`
+- Decoding: `ByteArray -> ArrayReadBuffer -> getRoot() -> FlexDecoderV2 -> T`
 
-The old broad experimental FlexBuffer encoder/store surface is no longer the supported API.
+### Native C++ utility layer
 
-Removed from the supported surface:
-- the old pointer-store style helper API
-- the earlier generic FlexBuffer writer path
+- `CBase` - C++ base utilities
+- `CppBase` - C++ class base
+- `Visitor` - Visitor pattern for C++ objects
+- `Matrix` - Geometry computation utilities
+- `NativeFlexBuffer` - C++ FlexBuffer creation and validation
 
-Kept and restored:
-- actual FlatBuffers / FlexBuffers dependency usage
-- the reusable native utility layer
-- the simple end-to-end native verification path used in BestBuds
+### Performance characteristics
+
+- Allocation-free after warmup (pooled builder + pooled structure stack)
+- Thread-safe per-operation (each encode/decode gets new pool instances)
+- Zero-copy primitive reads from buffer
+- O(log n) field lookup in maps via binary search
 
 ## Current verified scenario
 
@@ -28,3 +39,14 @@ BestBuds uses this module in a real device flow where:
 - C++ creates a FlexBuffer payload
 - Kotlin receives and decodes it
 - Maestro verifies the result on Android and iOS
+
+## What changed
+
+The old broad experimental FlexBuffer encoder/store surface is no longer the supported API. Only the V2 encoder/decoder and native utility layer are maintained.
+
+## Dependencies
+
+- `reaktor-core`
+- `flatbuffers-kotlin` (shared)
+- `reaktor-compiler` (KSP code generation)
+- `com.google.flatbuffers:flatbuffers-java` (Android)

--- a/reaktor-google/README.md
+++ b/reaktor-google/README.md
@@ -1,29 +1,54 @@
 # reaktor-google
 
-`reaktor-google` currently focuses on Google Cloud Pub/Sub integration.
+> **Stability: Experimental** - Pub/Sub is integrated and functional. Other Google services may be added.
+
+`reaktor-google` provides cross-platform abstractions for Google Cloud services, currently focused on Pub/Sub.
 
 ## What it provides
 
-- shared Pub/Sub data types
-- adapter abstraction for publish / subscribe / pull / ack flows
-- platform-specific adapters for JVM, Android, Darwin, and Web
-- a slot in `Feature.GooglePubSub` for runtime installation
+- Shared Pub/Sub data types
+- Adapter abstraction for publish / subscribe / pull / ack flows
+- Platform-specific adapters for JVM, Android, Darwin, and Web
+- A slot in `Feature.GooglePubSub` for runtime installation
 
-## Important types
+## Platforms
 
-- `PubSubTopic`
-- `PubSubSubscription`
-- `PubSubMessage`
-- `PulledPubSubMessage`
-- `PubSubAdapter`
+| Platform | Status |
+|---|---|
+| JVM | Fully functional via Google Cloud SDK |
+| Web/JS | Fully functional via REST API |
+| Android | Stub (designed for JVM server fallback) |
+| iOS/Darwin | Stub |
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `PubSubTopic` | Topic identifier (projectId + topicId) |
+| `PubSubSubscription` | Subscription identifier |
+| `PubSubMessage` | Message to publish (data + attributes + ordering key) |
+| `PulledPubSubMessage` | Message received from subscription |
+| `PubSubAdapter<Controller>` | Abstract platform adapter |
+
+## Operations
+
+- `ensureTopic()` - Create topic (idempotent)
+- `ensureSubscription()` - Create subscription (idempotent)
+- `publish()` - Publish messages with attributes and ordering keys
+- `pull()` - Fetch messages with max count
+- `acknowledge()` - Acknowledge pulled messages
+
+All operations return `Result` for error handling without exceptions.
+
+## Dependencies
+
+- `reaktor-auth` (shared)
+- Google Cloud Pub/Sub SDK (JVM server only)
+- Google Sheets API (JVM server only)
 
 ## Intended use
 
 Use this module when a product needs:
 - Pub/Sub publishing from shared code
-- a single abstraction across server and client runtimes
-- service endpoints backed by Pub/Sub topics
-
-## Status
-
-Pub/Sub is the primary implemented surface here. Other Google integrations should only live here if they can be kept product-neutral.
+- A single abstraction across server and client runtimes
+- Service endpoints backed by Pub/Sub topics

--- a/reaktor-graph/README.md
+++ b/reaktor-graph/README.md
@@ -1,58 +1,86 @@
 # reaktor-graph
 
-`reaktor-graph` is Reaktor's graph runtime.
+> **Stability: Stable**
+
+`reaktor-graph` is Reaktor's graph runtime. This is one of the most mature parts of Reaktor and is actively used by BestBuds in production.
 
 ## What it adds on top of `reaktor-core` and `reaktor-graph-port`
 
-- graph and node lifecycle
-- navigation and back stack management
-- scoped dependency injection
-- coroutine scope ownership
-- route nodes and container nodes
-- shared service integration
+- Graph and node lifecycle management
+- Navigation with back stack and cross-graph routing
+- Scoped dependency injection (Koin)
+- Coroutine scope ownership
+- Route nodes, container nodes, and controller nodes
+- Integrated service layer with interceptors
 - JSON export helpers for graph inspection
+
+## Platforms
+
+Android (Compose), iOS (Compose), JVM (Spring WebFlux), JavaScript/Web
 
 ## Main runtime types
 
-- `Graph`
-- `Node`
-- `BasicNode`
-- `ControllerNode`
-- `RouteNode`
-- `ContainerNode`
-- `Service`
-- `ServiceNode`
+### Graph
+
+`Graph` is the primary runtime container. It owns:
+- **Nodes** - a collection of `Node` instances
+- **DI scope** - a Koin scope with parent/child hierarchy
+- **Lifecycle state** - coordinated state transitions across all nodes
+- **Coroutine scope** - supervisor-based structured concurrency
+- **Navigation state** - observable back stack with route matching
+- **Port wiring** - `autoWire()` matches unconnected consumers to providers by type/key
+
+### Nodes
+
+| Type | Purpose |
+|---|---|
+| `BasicNode` | Simple logic unit, supports builder pattern |
+| `ControllerNode<State>` | Stateful node (ViewModel equivalent) with `MutableStateFlow<State>` |
+| `RouteNode<P, Binding>` | Navigation destination with URL-like route pattern |
+| `ContainerNode` | Holds nested child `Graph` instances (e.g., bottom navigation tabs) |
+| `ServiceNode` | Wraps a `Service`, exposing each handler as a typed `ProviderPort` |
+
+### Services
+
+Services are HTTP/RPC abstractions that work identically on client and server:
+
+- `Service` - abstract base with a list of `RequestHandler` instances
+- `GetHandler`, `PostHandler`, `PutHandler`, `DeleteHandler` - typed route handlers
+- `ServiceEndpoint` - URL, operation, and transport type
+- Interceptor chains for auth, logging, caching, error handling
+- `ServiceNode` wraps services as graph nodes for port-based wiring
+
+### Navigation
+
+- `RouteNode` defines URL-like patterns (`/chats`, `/chats/{id}`)
+- `NavigationEdge` connects routes with typed payloads
+- `NavCommand` variants: `Push`, `Pop`, `Replace`, `Return`
+- `BackStack` with observable state via `StateFlow`
+- Cross-graph navigation automatically bubbles up to find containers
 
 ## Core ideas
 
 ### Graph as runtime scope
 
-A graph owns:
-- nodes
-- DI scope
-- lifecycle state
-- coroutine scope
-- navigation state
-- local ports and auto-wiring
+A graph owns nodes, DI scope, lifecycle state, coroutine scope, navigation state, local ports, and auto-wiring. It is the fundamental unit of application composition.
 
 ### Nodes communicate through typed ports
 
-Nodes do not reach into each other directly. They communicate through provider and consumer ports wired by explicit edges or `autoWire()`.
+Nodes never call each other directly. They communicate through `ProviderPort<T>` and `ConsumerPort<T>` wired by explicit edges or `autoWire()`.
 
 ### Navigation is graph-native
 
-Navigation is not bolted on as a separate router. It is part of the graph runtime through route bindings, navigation edges, and container nodes.
+Navigation is part of the graph runtime through route bindings, navigation edges, and container nodes. It is not bolted on as a separate router.
 
 ### Services are part of the same model
 
-Service contracts sit inside the graph model instead of becoming a parallel architecture.
+Service contracts sit inside the graph model. A `ServiceNode` can be swapped transparently between a real server implementation and an HTTP client proxy.
 
-The current service layer preserves:
-- typed request/response models
-- route and method identity
-- transport metadata
-- interceptors and policy hooks
+## Dependencies
 
-## Current maturity
-
-This is one of the most mature parts of Reaktor and is actively used by BestBuds.
+- `reaktor-graph-port` - Port abstraction layer
+- `reaktor-ui` - Compose integration
+- `reaktor-db` - Database layer
+- Arrow - Functional programming utilities
+- Koin - Dependency injection
+- Spring WebFlux, Exposed ORM, PostgreSQL (server only)

--- a/reaktor-io/README.md
+++ b/reaktor-io/README.md
@@ -1,25 +1,46 @@
 # reaktor-io
 
+> **Stability: Stable**
+
 `reaktor-io` provides the shared transport-level utilities used by Reaktor services and routing.
 
 ## Responsibilities
 
-- route pattern parsing and filling
-- shared `Request` / `Response` shapes
-- environment propagation
-- typed service request handlers
-- client-side HTTP and websocket helpers
+- Route pattern parsing and parameter filling
+- Shared `Request` / `Response` shapes
+- Environment propagation (PROD, STAGE, DEV)
+- Typed service request handlers
+- Client-side HTTP (Ktor) and WebSocket helpers
+- Cross-platform file I/O and compression
 
-## Important concepts
+## Platforms
 
-- `RoutePattern`
-- `Request`
-- `Response`
-- `Environment`
-- typed handlers such as `GetHandler` and `PostHandler`
+Android, iOS (Darwin), JVM, JavaScript/Web
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `RoutePattern` | URL pattern parsing with regex and parameter extraction (e.g., `/{id}/something/{members}`) |
+| `Request` / `Response` | Base HTTP shapes with serialization support |
+| `Environment` | Runtime environment switching |
+| `GetHandler`, `PostHandler` | Typed route handlers |
+| `HttpClient` | Ktor-based HTTP client with middleware (logging, WebSocket, content negotiation) |
+| `PartySocket` | WebSocket abstraction with reconnection strategies |
+| `WebSocket` | Cross-platform WebSocket with Listener, Sender, Receiver |
+| `FileAdapter` | Cross-platform file I/O abstraction |
+| `Compressor` | Platform-specific compression (native on Android/Darwin/JVM) |
+| `ObjectSerializer` | Serialization interface layer |
 
 ## How it fits
 
 `reaktor-io` is the low-level transport utility layer.
 `reaktor-graph` uses it for its service model.
 Platform modules such as `reaktor-cloudflare` adapt those contracts to actual runtimes.
+
+## Dependencies
+
+- `reaktor-core`
+- `kotlinx-io-core` - I/O primitives
+- Ktor client with plugins (WebSocket, logging, content negotiation)
+- BuildKonfig - Build-time configuration

--- a/reaktor-location/README.md
+++ b/reaktor-location/README.md
@@ -1,19 +1,29 @@
 # reaktor-location
 
-`reaktor-location` provides location access through shared adapters.
+> **Stability: Early** - Intentionally minimal adapter surface, not a full mapping SDK.
 
-## Current surface
+`reaktor-location` provides cross-platform location access through shared adapters.
 
-- `Location`
-- `LocationAdapter`
-- `MapAdapter`
-- Android implementation
-- Darwin implementation
+## Platforms
+
+Android (Google Play Services), iOS/Darwin (CoreLocation)
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `Location` | Data class with `longitude`, `latitude` (serializable) |
+| `LocationAdapter<Controller>` | Abstract base with `getLocation()` suspend function |
+| `MapAdapter` | Map interface (placeholder) |
+| `AndroidLocationAdapter` | Android implementation via Google Play Services Location |
+| `DarwinLocationAdapter` | iOS implementation via CoreLocation framework |
 
 ## Goal
 
 Shared code should be able to request location without knowing whether the host is Android or iOS.
 
-## Status
+## Dependencies
 
-This module is intentionally small. It is an adapter surface, not a full mapping SDK.
+- `reaktor-ui`
+- Google Play Services Location 21.2.0 (Android)
+- CoreLocation framework (iOS/Darwin)

--- a/reaktor-media/README.md
+++ b/reaktor-media/README.md
@@ -1,22 +1,46 @@
 # reaktor-media
 
+> **Stability: Early** - Camera and gallery work on Android/iOS. Speech adapters are placeholders.
+
 `reaktor-media` is the media capability layer for Reaktor apps.
 
-## Responsibilities
+## Platforms
 
-- camera adapter surface
-- gallery/media selection hooks
-- image loading and caching helpers
-- speech recognition and synthesis abstractions
-- shared media-related support utilities
+Android (primary), iOS/Darwin (primary), JVM/JS (minimal)
 
 ## Current areas
 
-- Android camera integration
-- Darwin camera integration
-- Darwin gallery support
-- shared caches and image utilities
-- speech recognizer / synthesizer abstractions
+### Camera
+
+| Type | Purpose |
+|---|---|
+| `CameraAdapter<Controller>` | Abstract base with lifecycle (start, switchCamera), render, file/analyzer |
+| `CameraComponent` | Android camera implementation |
+| `DarwinCameraAdapter` | iOS camera implementation |
+| `CameraScreen` | Composable camera UI |
+| `ReaktorCamera` | Android camera wrapper |
+| `CameraStart` | Enum: Success, ControllerFailure, PermissionFailure, CameraFailure |
+
+### Gallery
+
+| Type | Purpose |
+|---|---|
+| `DarwinGalleryAdapter` | iOS gallery/media selection |
+
+### Image loading
+
+| Type | Purpose |
+|---|---|
+| `AsyncImage` | Image loading composable |
+| `Cache` / `FileBasedCache` | Image caching |
+| `CoilSetup` | Coil image library integration |
+
+### Speech (placeholders)
+
+| Type | Purpose |
+|---|---|
+| `SpeechRecognizer<Controller>` | Placeholder abstract class |
+| `SpeechSynthesizer<Controller>` | Placeholder abstract class |
 
 ## What this module is not
 
@@ -24,4 +48,10 @@ It is not a full backend media pipeline. Upload authorization, storage, and back
 - `reaktor-auth`
 - `reaktor-db`
 - `reaktor-work`
-- product-specific media services
+- Product-specific media services
+
+## Dependencies
+
+- `reaktor-graph`, `reaktor-io`
+- Coil 3.2.0 (image loading, network, SVG)
+- Android Camera, WorkManager (Android only)

--- a/reaktor-notification/README.md
+++ b/reaktor-notification/README.md
@@ -1,12 +1,24 @@
 # reaktor-notification
 
+> **Stability: Brainstorming** - Intentionally thin. Exists as a shared seam for future platform implementations.
+
 `reaktor-notification` is the shared notification adapter surface.
 
 ## Current purpose
 
-- provide a stable abstraction for notification delivery and registration
-- keep notification integration out of product code where possible
+- Provide a stable abstraction for notification delivery and registration
+- Keep notification integration out of product code where possible
+
+## Key types
+
+| Type | Purpose |
+|---|---|
+| `NotificationAdapter<Controller>` | Abstract base extending the core `Adapter` framework |
+
+## Platforms
+
+Android, iOS (Darwin), JVM, JavaScript/Web (all via build configuration, implementation pending)
 
 ## Status
 
-This module is still intentionally thin. It exists as the shared seam for platform-specific notification implementations.
+This module is a placeholder. It defines the adapter surface so that platform-specific notification implementations (FCM, APNs, etc.) can be wired in later without changing product code.

--- a/reaktor-react/README.md
+++ b/reaktor-react/README.md
@@ -1,11 +1,20 @@
 # reaktor-react
 
-`reaktor-react` is currently paused.
+> **Stability: Paused** - Not actively maintained. Kept for historical reference.
+
+`reaktor-react` was Reaktor's React Native integration layer, providing JSI (JavaScript Interface) bridge support.
+
+## What it contained
+
+- `JSIManager` - Native module interface for React Native
+- `Invoker` - Function invocation across JSI boundary
+- `FlowHandle` - Reactive flow bridging to React Native
+- `Promise` - Promise wrapper type
+- `NetworkModule` - Network API exposed to React Native
+- Android and iOS platform-specific JSI bindings
 
 ## Status
 
-- not an active investment area right now
-- kept in the repo because parts of the older bridge/runtime work still live here
-- should not be the default place for new work unless the direction is explicitly revived
+This module is not an active investment area. It is kept in the repo because parts of the older bridge/runtime work still live here. It targets React Native 0.68.5.
 
-If you are adding new cross-platform app runtime features, prefer the actively maintained modules instead.
+If you are adding new cross-platform app runtime features, prefer the actively maintained modules (`reaktor-graph`, `reaktor-ffi`, `reaktor-ui`) instead.

--- a/reaktor-tactile/README.md
+++ b/reaktor-tactile/README.md
@@ -1,7 +1,16 @@
 # reaktor-tactile
 
+> **Stability: Brainstorming** - Not built out yet. Placeholder for future development.
+
 `reaktor-tactile` is reserved for touch and haptics-related abstractions.
+
+## Intended scope
+
+- Vibration feedback patterns
+- Pressure sensitivity adapters
+- Haptic engine integration (iOS Taptic Engine, Android vibrator)
+- Touch gesture abstractions
 
 ## Status
 
-This module is not built out yet. Treat it as a placeholder for future product-neutral tactile and haptics APIs.
+This module has no source files. It exists as a placeholder for future product-neutral tactile and haptics APIs. The build configuration is in place but no implementation has started.

--- a/reaktor-ui/README.md
+++ b/reaktor-ui/README.md
@@ -1,25 +1,53 @@
 # reaktor-ui
 
-`reaktor-ui` is the shared UI layer for Reaktor apps.
+> **Stability: Early** - Functional for current scope but not a polished public design system.
+
+`reaktor-ui` is the shared UI layer for Reaktor apps, providing Compose-first components and design tokens.
+
+## Platforms
+
+Android (Compose), iOS (Compose), JVM (Compose Desktop), JavaScript/Web (React wrappers)
 
 ## What it contains
 
-- design tokens
-- shared UI primitives
-- Compose-first component implementations
-- cross-platform theming ideas that can also back web surfaces
+### Design tokens
+
+- `DesignTokens` / `TokenFactory` - Design token system
+- `MaterialTokens` - Material3 token definitions
+- `LightColors` / `DarkColors` - Color schemes
+- `ReaktorThemeProvider` / `ReaktorDesignSystem` - Theme provider composables
+
+### Compose components (atoms)
+
+`Button`, `Divider`, `Icon`, `Input`, `Badge`, `Chip`, `Card`, `Progress`, `Avatar`, `Text`, `Toggle`, `Spacer`
+
+### Compose components (molecules)
+
+`EmptyState`, `SearchBar`, `ListItem`
+
+### Theme
+
+`Theme` is the customizable theme with composable factories:
+- `ButtonPrimary`, `ButtonSecondary`, `ButtonIcon`, `ButtonFloatingAction`
+- `TextView`, `CardView`, `InputText`, `Space`
+
+### Web components
+
+`WebButton`, `WebText`, `WebCard`, `WebComponent` - React-compatible wrappers
+
+### Layout
+
+`Responsive` - Adaptive layout helpers for different screen sizes
 
 ## Design goals
 
-- keep visual language consistent across products
-- avoid product code hardcoding sizes, spacing, and semantic colors everywhere
-- provide reusable UI components without forcing a single visual style forever
+- Keep visual language consistent across products
+- Avoid product code hardcoding sizes, spacing, and semantic colors
+- Provide reusable UI components without forcing a single visual style
 
-## Current scope
+## Dependencies
 
-The module is most useful today for:
-- Compose-based shared UI
-- design token definitions
-- component primitives used by app code
-
-It is not yet a polished public design system package.
+- `reaktor-core`, `reaktor-io`
+- Compose runtime, foundation, material3, material-icons-extended
+- Coil 3.2.0 (image loading, network, SVG)
+- Kotlin wrappers + React (web)

--- a/reaktor-work/README.md
+++ b/reaktor-work/README.md
@@ -1,26 +1,53 @@
 # reaktor-work
 
-`reaktor-work` is Reaktor's background task orchestration layer.
+> **Stability: Experimental** - Functional with platform-native schedulers. API may evolve.
+
+`reaktor-work` is Reaktor's background task orchestration layer. Products define work in shared Kotlin code; the platform's task manager (Android WorkManager, iOS BGTaskScheduler, JVM scheduler, or Node.js) handles actual scheduling and execution.
+
+## Platforms
+
+Android, iOS (Darwin), JVM, JavaScript/Web
 
 ## Core types
 
-- `TaskManager`
-- `Worker<TPayload>`
-- platform task manager implementations for Android, iOS, JVM, and JS
+| Type | Purpose |
+|---|---|
+| `TaskManager<Controller>` | Abstract base; delegates to platform manager |
+| `AndroidTaskManager` | Android WorkManager implementation |
+| `DarwinTaskManager` | iOS BGTaskScheduler implementation |
+| `JvmTaskManager` | JVM/server implementation |
+| `JsTaskManager` | JavaScript/Node.js implementation |
+| `Worker<TPayload>` | Base class for reusable task implementations |
 
 ## Built-in worker shapes
 
-The module currently ships reusable worker types such as:
-- sync
-- token refresh
-- analytics upload
-- media upload
-- database maintenance
-- cache cleanup
-- notification sync
-- heartbeat
-- prefetch
-- log upload
+| Worker | Purpose |
+|---|---|
+| `SyncWorker` | Periodic data synchronization |
+| `TokenRefreshWorker` | OAuth token refresh before expiry |
+| `AnalyticsUploadWorker` | Batch upload of analytics events |
+| `MediaUploadWorker` | Upload pending media files |
+| `DatabaseMaintenanceWorker` | Database optimization (vacuum, compact) |
+| `CacheCleanupWorker` | Remove expired cache entries |
+| `NotificationSyncWorker` | Sync notification state |
+| `HeartbeatWorker` | Periodic keep-alive |
+| `PrefetchWorker` | Preload content for offline use |
+| `LogUploadWorker` | Collect and upload logs |
+
+## Task capabilities
+
+- One-time and periodic scheduling
+- Initial delay and flex windows
+- Backoff configuration (min: 15s, max retries: 3)
+- Max parallel tasks (4 concurrent by default)
+- Task status monitoring and cancellation
+- Observable task flows
+
+## Dependencies
+
+- `reaktor-core`
+- Meeseeks runtime (unified task scheduling framework)
+- Koin dependency injection (JVM)
 
 ## Goal
 


### PR DESCRIPTION
Mark generated HTML docs (Dokka, per-module docs/) and website as
linguist-documentation so GitHub shows accurate language distribution
(Kotlin, C++, TypeScript instead of HTML).

Rewrite README.md with comprehensive module catalog including stability
levels (Stable/Experimental/Early/Brainstorming/Paused), platform
targets, key types, architecture overview, and technology stack.

Update all 16 module READMEs with stability badges, detailed type
tables, platform coverage, dependency lists, and usage guidance.

https://claude.ai/code/session_012pmVVyfws1SWhZNcGNvC36