### PR TITLE
Fix linguist stats and add graph blueprint image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,12 +8,17 @@ dependeasy/bin/** linguist-generated=true
 *.mjs.map linguist-generated=true
 *.d.mts linguist-generated=true
 
-# Generated documentation (HTML from Dokka/KDoc)
-docs/** linguist-documentation=true
-**/docs/**/*.html linguist-documentation=true
+# Generated documentation (Dokka HTML) - use linguist-generated to fully exclude
+docs/** linguist-generated=true
+reaktor-core/docs/** linguist-generated=true
+reaktor-db/docs/** linguist-generated=true
+reaktor-io/docs/** linguist-generated=true
+reaktor-ui/docs/** linguist-generated=true
+**/docs/**/*.html linguist-generated=true
+*.html linguist-documentation=true
 
 # Website (Docusaurus)
-website/** linguist-documentation=true
+website/** linguist-generated=true
 
 # Experiments
 experiments/** linguist-vendored=true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is the shared runtime used by:
 
 The graph blueprint is a live visualization of how a Reaktor application is assembled. Every screen, service, repository, and navigation binding is a node in the graph, wired together through typed ports and edges.
 
-![Reaktor Graph Blueprint - BestBuds application graph showing nodes, routes, containers, services, and navigation wires](assets/graph-blueprint.png)
+![Reaktor Graph Blueprint - BestBuds application graph showing nodes, routes, containers, services, and navigation wires](https://media.licdn.com/dms/image/v2/D5622AQEjWgnHCS6qVQ/feedshare-shrink_800/B56Z1DUxzQGYAc-/0/1774951013900?e=2147483647&v=beta&t=78ucaCV3dKt5uHDhILM6wr8WlGcwEbZYmm0YC-Ah2i4)
 
 *BestBuds running on Reaktor: screens (green), routes (blue), containers (yellow), services/data (orange), with navigation wires (dark blue) and data wires (green lines) connecting them.*
 


### PR DESCRIPTION
## Summary

- Switch all generated Dokka HTML directories from `linguist-documentation` to `linguist-generated` for complete exclusion from GitHub language stats (Kotlin, C++, TypeScript should now show correctly instead of HTML)
- Add explicit `.gitattributes` paths for each module's `docs/` directory and a `*.html` fallback
- Embed the graph blueprint image in the README using the LinkedIn CDN URL

## Test plan

- [ ] Verify GitHub language stats bar shows Kotlin/C++/TypeScript after merge
- [ ] Verify graph blueprint image renders in README on GitHub

https://claude.ai/code/session_012pmVVyfws1SWhZNcGNvC36